### PR TITLE
skip .dockerignore check for Dockerfile

### DIFF
--- a/doc/extensions/acrbuildext/azext_acrbuildext/__init__.py
+++ b/doc/extensions/acrbuildext/azext_acrbuildext/__init__.py
@@ -32,7 +32,7 @@ class AcrBuildCommandsLoader(AzCommandsLoader):
 
     def load_arguments(self, _):
         with self.argument_context('acr build') as c:
-            c.argument('registry_name', options_list=['--registry', '-r'], help='The container registry. You can configure the default registry using `az configure --defaults acr=<registry name>`', completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE), configured_default='acr')
+            c.argument('registry_name', options_list=['--registry', '-r'], help='The name of the container registry. You can configure the default registry name using `az configure --defaults acr=<registry name>`', completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE), configured_default='acr')
             c.argument('image_name', options_list=['--image', '-t'], help="The image repository and optionally a tag in the 'repository:tag' format.")
             c.argument('source_location', options_list=['--context', '-c'], help="The local source code directory path (eg, './src') or the url to a git repository (eg, 'https://github.com/docker/rootfs.git') or a remote tarball (eg, 'http://server/context.tar.gz').")
             c.argument('docker_file_path', options_list=['--file', '-f'], help="The relative path of the the docker file to the source code root folder (Default is 'Dockerfile').")

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
@@ -90,6 +90,7 @@ def load_arguments(self, _):
 
     with self.argument_context('acr build') as c:
         c.argument('build_id', help='The unique build identifier.')
+        c.argument('registry_name', options_list=['--registry', '-r'], help='The name of the container registry. You can configure the default registry name using `az configure --defaults acr=<registry name>`', completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE), configured_default='acr')
         c.argument('image_name', options_list=['--image', '-t'], help="The image repository and optionally a tag in the 'repository:tag' format.")
         c.argument('source_location', options_list=['--context', '-c'], help="The local source code directory path (eg, './src') or the url to a git repository (eg, 'https://github.com/docker/rootfs.git') or a remote tarball (eg, 'http://server/context.tar.gz').")
         c.argument('docker_file_path', options_list=['--file', '-f'], help="The relative path of the the docker file to the source code root folder (Default is 'Dockerfile').")


### PR DESCRIPTION
When we archive the source code, we filter the files based on .dockerignore. However, .dockerignore can also exclude Dockerfile itself (docker build handles Dockerfile separately). In our case, we need to always include Dockerfile.

Here is an example: https://github.com/Azure/acr-builder/blob/master/.dockerignore 