### PR TITLE
Increase show logs timeout

### DIFF
--- a/doc/extensions/acrbuildext/azext_acrbuildext/build.py
+++ b/doc/extensions/acrbuildext/azext_acrbuildext/build.py
@@ -57,7 +57,7 @@ def acr_build_show_logs(cmd,
     account_name, endpoint_suffix, container_name, blob_name, sas_token = _get_blob_info(log_file_sas)
 
     byte_size = 1024*4
-    timeout_in_minutes = 10
+    timeout_in_minutes = 30
     timeout_in_seconds = timeout_in_minutes * 60
 
     _stream_logs(byte_size, timeout_in_seconds,

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -57,7 +57,7 @@ def acr_build_show_logs(cmd,
     account_name, endpoint_suffix, container_name, blob_name, sas_token = _get_blob_info(log_file_sas)
 
     byte_size = 1024*4
-    timeout_in_minutes = 10
+    timeout_in_minutes = 30
     timeout_in_seconds = timeout_in_minutes * 60
 
     _stream_logs(byte_size, timeout_in_seconds,


### PR DESCRIPTION
Increase show logs timeout to 30 minutes, up from 10. This timeout means: "if the logs haven't changed in X minutes then display an error message from the client"

If a download is extremely large or the network is slow enough it might take more than 10 minutes to process and there might not be any logs committed in that time.