### PR TITLE
Ignore errors during utf-8 conversion

### DIFF
--- a/doc/extensions/acrbuildext/azext_acrbuildext/build.py
+++ b/doc/extensions/acrbuildext/azext_acrbuildext/build.py
@@ -123,7 +123,7 @@ def _stream_logs(byte_size,
                         flush = curr_bytes[:i]  # won't print \n
                         stream = BytesIO()
                         stream.write(curr_bytes[i+1:])
-                        print(flush.decode('utf-8'))
+                        print(flush.decode('utf-8', errors='ignore'))
                         break
 
             except AzureHttpError as ae:
@@ -132,7 +132,7 @@ def _stream_logs(byte_size,
             except KeyboardInterrupt:
                 curr_bytes = stream.getvalue()
                 if len(curr_bytes) > 0:
-                    print(curr_bytes.decode('utf-8'))
+                    print(curr_bytes.decode('utf-8', errors='ignore'))
                 return
 
         try:
@@ -147,7 +147,7 @@ def _stream_logs(byte_size,
                 raise CLIError(ae)
         except KeyboardInterrupt:
             if len(curr_bytes) > 0:
-                print(curr_bytes.decode('utf-8'))
+                print(curr_bytes.decode('utf-8', errors='ignore'))
             return
         except Exception as err:
             raise CLIError(err)
@@ -244,7 +244,7 @@ def acr_queue(cmd,
 
     # hard-code platform to linux and cpu to 1
     platform = PlatformProperties("Linux")
-    
+
     build_arguments = []
     if not (build_args is None):
         for name_value in build_args:
@@ -296,7 +296,8 @@ def acr_queue(cmd,
             result.build_id))
 
     if no_logs == False:
-        acr_build_show_logs(cmd, client, registry_name, result.build_id, resource_group_name)
+        acr_build_show_logs(cmd, client, registry_name,
+                            result.build_id, resource_group_name)
 
 
 def _check_local_docker_file(source_location, docker_file_path):
@@ -379,9 +380,10 @@ def _upload_source_code(client, registry_name, resource_group_name, source_locat
                 return tarinfo
 
             # always include docker file
-            # file path comparision is case-sensitive 
+            # file path comparision is case-sensitive
             if tarinfo.name == docker_file_path:
-                logger.debug(".dockerignore: skip checking '{}'".format(docker_file_path))
+                logger.debug(
+                    ".dockerignore: skip checking '{}'".format(docker_file_path))
                 return tarinfo
 
             for item in ignore_list:

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -123,7 +123,7 @@ def _stream_logs(byte_size,
                         flush = curr_bytes[:i]  # won't print \n
                         stream = BytesIO()
                         stream.write(curr_bytes[i+1:])
-                        print(flush.decode('utf-8'))
+                        print(flush.decode('utf-8', errors='ignore'))
                         break
 
             except AzureHttpError as ae:
@@ -132,7 +132,7 @@ def _stream_logs(byte_size,
             except KeyboardInterrupt:
                 curr_bytes = stream.getvalue()
                 if len(curr_bytes) > 0:
-                    print(curr_bytes.decode('utf-8'))
+                    print(curr_bytes.decode('utf-8', errors='ignore'))
                 return
 
         try:
@@ -147,7 +147,7 @@ def _stream_logs(byte_size,
                 raise CLIError(ae)
         except KeyboardInterrupt:
             if len(curr_bytes) > 0:
-                print(curr_bytes.decode('utf-8'))
+                print(curr_bytes.decode('utf-8', errors='ignore'))
             return
         except Exception as err:
             raise CLIError(err)
@@ -296,7 +296,8 @@ def acr_queue(cmd,
             result.build_id))
 
     if no_logs == False:
-        acr_build_show_logs(cmd, client, registry_name, result.build_id, resource_group_name)
+        acr_build_show_logs(cmd, client, registry_name,
+                            result.build_id, resource_group_name)
 
 
 def _check_local_docker_file(source_location, docker_file_path):
@@ -379,9 +380,10 @@ def _upload_source_code(client, registry_name, resource_group_name, source_locat
                 return tarinfo
 
             # always include docker file
-            # file path comparision is case-sensitive 
+            # file path comparision is case-sensitive
             if tarinfo.name == docker_file_path:
-                logger.debug(".dockerignore: skip checking '{}'".format(docker_file_path))
+                logger.debug(
+                    ".dockerignore: skip checking '{}'".format(docker_file_path))
                 return tarinfo
 
             for item in ignore_list:


### PR DESCRIPTION
Skip any characters we can't convert. Right now the client makes the assumption that the source is always utf-8, but if the server lies the client can't progress any further - so the worst case is just to trim the bad bytes.