### PR TITLE
Sync client factory, build, and build task files from CLI to ext

### DIFF
--- a/doc/extensions/acrbuildext/azext_acrbuildext/_client_factory.py
+++ b/doc/extensions/acrbuildext/azext_acrbuildext/_client_factory.py
@@ -30,13 +30,25 @@ def get_acr_build_client(cli_ctx, api_version=None):
     return get_mgmt_service_client(cli_ctx, ContainerRegistryManagementClient, api_version=api_version)
 
 
+def cf_acr_registries(cli_ctx, *_):
+    return get_acr_service_client(cli_ctx).registries
+
+
+def cf_acr_replications(cli_ctx, *_):
+    return get_acr_service_client(cli_ctx).replications
+
+
+def cf_acr_webhooks(cli_ctx, *_):
+    return get_acr_service_client(cli_ctx).webhooks
+
+
 def cf_acr_builds(cli_ctx, *_):
     return get_acr_build_client(cli_ctx).builds
 
 
 def cf_acr_build_tasks(cli_ctx, *_):
     return get_acr_build_client(cli_ctx).build_tasks
- 
 
-def cf_acr_registries(cli_ctx, *_):
+
+def cf_acr_build_registries(cli_ctx, *_):
     return get_acr_build_client(cli_ctx).registries

--- a/doc/extensions/acrbuildext/azext_acrbuildext/build.py
+++ b/doc/extensions/acrbuildext/azext_acrbuildext/build.py
@@ -33,7 +33,7 @@ from azure.cli.core.commands import LongRunningOperation
 from knack.util import CLIError
 from knack.log import get_logger
 
-from ._client_factory import cf_acr_registries
+from ._client_factory import cf_acr_build_registries
 
 logger = get_logger(__name__)
 
@@ -224,7 +224,7 @@ def acr_queue(cmd,
     resource_group_name = get_resource_group_name_by_registry_name(
         cmd.cli_ctx, registry_name, resource_group_name)
 
-    client_registries = cf_acr_registries(cmd.cli_ctx)
+    client_registries = cf_acr_build_registries(cmd.cli_ctx)
 
     if docker_file_path is None:
         docker_file_path = "Dockerfile"

--- a/doc/extensions/acrbuildext/azext_acrbuildext/build_task.py
+++ b/doc/extensions/acrbuildext/azext_acrbuildext/build_task.py
@@ -111,8 +111,8 @@ def acr_build_task_run(
     _, resource_group_name = validate_managed_registry(
         cmd.cli_ctx, registry_name, resource_group_name, BUILD_TASKS_NOT_SUPPORTED)
 
-    from ._client_factory import cf_acr_registries
-    client_registries = cf_acr_registries(cmd.cli_ctx)
+    from ._client_factory import cf_acr_build_registries
+    client_registries = cf_acr_build_registries(cmd.cli_ctx)
     buildRequest = {
         "type": "BuildTask",
         "buildTaskName": build_task_name

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_client_factory.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_client_factory.py
@@ -49,5 +49,6 @@ def cf_acr_builds(cli_ctx, *_):
 def cf_acr_build_tasks(cli_ctx, *_):
     return get_acr_build_client(cli_ctx).build_tasks
 
+
 def cf_acr_build_registries(cli_ctx, *_):
     return get_acr_build_client(cli_ctx).registries


### PR DESCRIPTION
Made a direct symlink to the important files from `/extension` and the CLI. For those using Linux, you can use `ln -sfn` to do the same. This is the delta between the two right now.

Note: not all files are possible to have a direct symlink as they're quite different, so any temporay packaging/removal solution should consider that.