### PR TITLE
Support multiple build-args

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
@@ -39,6 +39,12 @@ def load_arguments(self, _):
         c.argument('password_name', help='The name of password to regenerate', choices=['password', 'password2'])
         c.argument('username', options_list=['--username', '-u'], help='The username used to log into a container registry')
         c.argument('password', options_list=['--password', '-p'], help='The password used to log into a container registry')
+        c.argument('build_id', help='The unique build identifier.')
+        c.argument('image_name', options_list=['--image', '-t'], help="The image repository and optionally a tag in the 'repository:tag' format.")
+        c.argument('docker_file_path', options_list=['--file', '-f'], help="The relative path of the the docker file to the source code root folder.")        
+        c.argument('build_arg', help='Build argument in a format of <name>=<value>.', action='append')
+        c.argument('secret_build_arg', help='Secret build argument in a format of <name>=<value>.', action='append')
+        c.argument('no_logs', help="Do not show logs after successfully queuing the build.", action='store_true')
 
     with self.argument_context('acr create') as c:
         c.argument('admin_enabled', nargs='?', required=False, const='true', default='false', help='Indicates whether the admin user is enabled', choices=['true', 'false'])
@@ -90,28 +96,18 @@ def load_arguments(self, _):
         c.argument('replication_name', help='The name of the replication. Default to the location name.', completer=None)
 
     with self.argument_context('acr build') as c:
-        c.argument('build_id', help='The unique build identifier.')
-        c.argument('registry_name', options_list=['--registry', '-r'], help='The name of the container registry. You can configure the default registry name using `az configure --defaults acr=<registry name>`', completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE), configured_default='acr')
-        c.argument('image_name', options_list=['--image', '-t'], help="The image repository and optionally a tag in the 'repository:tag' format.")
+        c.argument('registry_name', options_list=['--registry', '-r'])
         c.argument('source_location', options_list=['--context', '-c'], help="The local source code directory path (eg, './src') or the url to a git repository (eg, 'https://github.com/docker/rootfs.git') or a remote tarball (eg, 'http://server/context.tar.gz').")
-        c.argument('docker_file_path', options_list=['--file', '-f'], help="The relative path of the the docker file to the source code root folder (Default is 'Dockerfile').")
         c.argument('timeout', help='The build timeout in seconds.')
-        c.argument('build_args', nargs='+', help='The space-separated build arguments in a format of <name>=<value>.')
-        c.argument('secret_build_args', nargs='+', help='The space-separated secret build arguments in a format of <name>=<value>.')
-        c.argument('no_logs', options_list=['--no-logs'], action='store_true', help='Do not show logs after successfully queuing the build.')
 
     with self.argument_context('acr build-task') as c:
-        c.argument('registry_name', options_list=['--registry', '-r'], help='The name of the container registry. You can configure the default registry name using `az configure --defaults acr=<registry name>`', completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE), configured_default='acr')
+        c.argument('registry_name', options_list=['--registry', '-r'])
         c.argument('build_task_name', options_list=['--name', '-n'], help='The name of the build task', completer=get_resource_name_completion_list(BUILD_TASK_RESOURCE_TYPE))
-        c.argument('build_id', help='The unique build identifier.')
-        c.argument('image_name', options_list=['--image', '-t'], help="The image repository and optionally a tag in the 'repository:tag' format.")
         c.argument('source_location', options_list=['--context', '-c'], help="The URL to a git repository.")
         c.argument('source_branch', options_list=['--branch'], help="The source control branch name")
-        c.argument('docker_file_path', options_list=['--file', '-f'], help="The relative path of the the docker file to the source code root folder.")
         c.argument('git_access_token', help="The git access token for configuring webhook.")
         c.argument('os_type', options_list=['--os'], help="The platform OS that has to be used for build task.")
         c.argument('cpu', help="The number of cpu cores to use for running builds.")
-        c.argument('no_logs', action='store_true', help="Do not show build logs.")
 
     with self.argument_context('acr build-task create') as c:
         c.argument('build_task_name', completer=None)

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_utils.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_utils.py
@@ -21,6 +21,8 @@ from ._client_factory import (
     get_acr_service_client
 )
 
+from .sdk.models import BuildArgument
+
 
 def _arm_get_resource_by_name(cli_ctx, resource_name, resource_type):
     """Returns the ARM resource in the current subscription with resource_name.
@@ -201,6 +203,7 @@ def arm_deploy_template_build_task_create(
     source_branch,         
     image_name,
     docker_file_path,
+    build_arguments,
     git_access_token,
     os_type,
     cpu,
@@ -217,7 +220,6 @@ def arm_deploy_template_build_task_create(
     from azure.mgmt.resource.resources.models import DeploymentProperties
     from azure.cli.core.util import get_file_json
     import os
-    import random
 
     # TODO ankheman remove hard-coded values
     parameters = {
@@ -239,6 +241,7 @@ def arm_deploy_template_build_task_create(
         'sourceControlAuthExpiresIn': {'value': 1313141},
         'stepName': {'value': build_task_name + "StepName"},
         'dockerFilePath': {'value': docker_file_path},
+        'buildArguments': {'value': build_arguments},
         'SourceControlBranch': {'value': source_branch},
         'imageName': {'value': image_name},
         'isPushEnabled': {'value': True},
@@ -369,3 +372,16 @@ def _invalid_sku_update():
 
 def _invalid_sku_downgrade():
     raise CLIError("Managed registries could not be downgraded to Classic SKU.")
+
+
+def validate_and_serialize_build_arguments(
+    build_arg,
+    build_arguments,
+    is_secret):
+    
+    if build_arg is not None:
+        for name_value in build_arg:
+            if "=" not in name_value:
+                raise CLIError("Accepted format for arg is <name>=<value>.")
+            name, value = name_value.split('=', 1)
+            build_arguments.append(BuildArgument(name, value, is_secret))

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_utils.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_utils.py
@@ -209,12 +209,18 @@ def arm_deploy_template_build_task_create(
     cpu,
     deployment_name=None):
     """Deploys ARM template to create a build task.
-    :param str resource_group_name: The name of resource group
+    :param str build_task_name: The name of build task
     :param str registry_name: The name of container registry
-    :param str location: The name of location
-    :param str sku: The SKU of the container registry
-    :param str storage_account_name: The name of storage account
-    :param bool admin_user_enabled: Enable admin user
+    :param str registry_location: The registry location
+    :param str resource_group_name: The name of resource group
+    :param str context: The URL to a git repository.
+    :param str source_branch: The source control branch name.
+    :param str image_name: The name of the image.
+    :param str docker_file_path: The relative path of the the docker file to the source code root folder.
+    :param str[] build_arguments: List of build arguments.
+    :param str git_access_token: The git access token for configuring webhook.
+    :param str os_type: The platform OS that has to be used for build task.
+    :param str cpu: The number of cpu cores to use for running builds.
     :param str deployment_name: The name of the deployment
     """
     from azure.mgmt.resource.resources.models import DeploymentProperties
@@ -374,11 +380,15 @@ def _invalid_sku_downgrade():
     raise CLIError("Managed registries could not be downgraded to Classic SKU.")
 
 
-def validate_and_serialize_build_arguments(
+def validate_and_append_build_arguments(
     build_arg,
     build_arguments,
     is_secret):
-    
+    """Returns a tuple of Registry object and resource group name.
+    :param str[] build_arg: List of build arguments provided by user
+    :param str[] build_arguments: Mutable list of build_arg and secret_build_arg.
+    :param bool is_secret: arguments in build_arg are secret.
+    """  
     if build_arg is not None:
         for name_value in build_arg:
             if "=" not in name_value:

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -30,7 +30,7 @@ from .sdk.models import (
 )
 from ._utils import (
     get_resource_group_name_by_registry_name,
-    validate_and_serialize_build_arguments
+    validate_and_append_build_arguments
 )
 from azure.cli.core.commands import LongRunningOperation
 from knack.util import CLIError
@@ -260,8 +260,8 @@ def acr_queue(cmd,
     platform = PlatformProperties("Linux")
 
     build_arguments = []
-    validate_and_serialize_build_arguments(build_arg, build_arguments, False)
-    validate_and_serialize_build_arguments(secret_build_arg, build_arguments, True)
+    validate_and_append_build_arguments(build_arg, build_arguments, False)
+    validate_and_append_build_arguments(secret_build_arg, build_arguments, True)
 
     build_request = QuickBuildRequest(
         source_location=source_location,

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -28,7 +28,10 @@ from .sdk.models import (
     BuildArgument,
     SourceUploadDefinition
 )
-from ._utils import get_resource_group_name_by_registry_name
+from ._utils import (
+    get_resource_group_name_by_registry_name,
+    validate_and_serialize_build_arguments
+)
 from azure.cli.core.commands import LongRunningOperation
 from knack.util import CLIError
 from knack.log import get_logger
@@ -214,20 +217,17 @@ def acr_queue(cmd,
               registry_name,
               source_location,
               image_name=None,
-              docker_file_path=None,
               resource_group_name=None,
               timeout=None,
-              build_args=None,
-              secret_build_args=None,
+              build_arg=None,
+              secret_build_arg=None,
+              docker_file_path="Dockerfile",
               no_logs=False):
 
     resource_group_name = get_resource_group_name_by_registry_name(
         cmd.cli_ctx, registry_name, resource_group_name)
 
     client_registries = cf_acr_build_registries(cmd.cli_ctx)
-
-    if docker_file_path is None:
-        docker_file_path = "Dockerfile"
 
     if source_location is None:
         source_location = "."
@@ -260,15 +260,8 @@ def acr_queue(cmd,
     platform = PlatformProperties("Linux")
 
     build_arguments = []
-    if not (build_args is None):
-        for name_value in build_args:
-            name, value = name_value.split('=', 1)
-            build_arguments.append(BuildArgument(name, value, False))
-
-    if not (secret_build_args is None):
-        for name_value in secret_build_args:
-            name, value = name_value.split('=', 1)
-            build_arguments.append(BuildArgument(name, value, True))
+    validate_and_serialize_build_arguments(build_arg, build_arguments, False)
+    validate_and_serialize_build_arguments(secret_build_arg, build_arguments, True)
 
     build_request = QuickBuildRequest(
         source_location=source_location,

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build_task.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build_task.py
@@ -4,9 +4,11 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.cli.core.commands import LongRunningOperation
+from knack.util import CLIError
 from ._utils import (
     arm_deploy_template_build_task_create,
-    validate_managed_registry
+    validate_managed_registry,
+    validate_and_serialize_build_arguments
 )
 from .build import _check_image_name
 
@@ -22,13 +24,18 @@ def acr_build_task_create(
     image_name,
     git_access_token,
     source_branch="master",  
-    docker_file_path='Dockerfile',
+    docker_file_path="Dockerfile",
     os_type="Linux",
     cpu=1,
+    build_arg=None,
+    secret_build_arg=None,
     resource_group_name=None):
     
     registry, resource_group_name = validate_managed_registry(
         cmd.cli_ctx, registry_name, resource_group_name, BUILD_TASKS_NOT_SUPPORTED)
+    build_arguments = []
+    validate_and_serialize_build_arguments(build_arg, build_arguments, False)
+    validate_and_serialize_build_arguments(secret_build_arg, build_arguments, True)
 
     LongRunningOperation(cmd.cli_ctx)(
             arm_deploy_template_build_task_create(
@@ -41,6 +48,7 @@ def acr_build_task_create(
                 source_branch,              
                 _check_image_name(image_name),
                 docker_file_path,
+                build_arguments,
                 git_access_token,
                 os_type,
                 cpu)

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build_task.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build_task.py
@@ -8,7 +8,7 @@ from knack.util import CLIError
 from ._utils import (
     arm_deploy_template_build_task_create,
     validate_managed_registry,
-    validate_and_serialize_build_arguments
+    validate_and_append_build_arguments
 )
 from .build import _check_image_name
 
@@ -34,8 +34,8 @@ def acr_build_task_create(
     registry, resource_group_name = validate_managed_registry(
         cmd.cli_ctx, registry_name, resource_group_name, BUILD_TASKS_NOT_SUPPORTED)
     build_arguments = []
-    validate_and_serialize_build_arguments(build_arg, build_arguments, False)
-    validate_and_serialize_build_arguments(secret_build_arg, build_arguments, True)
+    validate_and_append_build_arguments(build_arg, build_arguments, False)
+    validate_and_append_build_arguments(secret_build_arg, build_arguments, True)
 
     LongRunningOperation(cmd.cli_ctx)(
             arm_deploy_template_build_task_create(

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/template_build_task_create.json
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/template_build_task_create.json
@@ -113,6 +113,13 @@
                 "description": "the path to the docker file in the source control."
             }
         },
+        "buildArguments": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "Build arguments"
+            }
+        },
         "sourceControlBranch": {
             "type": "string",
             "metadata": {
@@ -172,7 +179,8 @@
                 "branch": "[parameters('sourceControlBranch')]",
                 "imageName": "[parameters('imageName')]",
                 "isPushEnabled": "[parameters('isPushEnabled')]",
-                "dockerFilePath": "[parameters('dockerFilePath')]"
+                "dockerFilePath": "[parameters('dockerFilePath')]",
+                "buildArguments": "[parameters('buildArguments')]"
             }
         }
     ]


### PR DESCRIPTION
Support `--build-arg` like docker build.
--secret-build-arg for secret args.

can chain multiple build-args:
--build-arg NAME1=value1 --build-arg NAME2=value2

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
