### PR TITLE
Introduce linear backoff for client sleep time

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -183,11 +183,13 @@ def _stream_logs(byte_size,
         if (_blob_is_not_complete(metadata) and start >= available):
             num_fails += 1
             
+            logger.debug("Failed to find new content '{}' times in a row".format(num_fails))
             if num_fails >= num_fails_for_backoff:
                 num_fails = 0
                 sleep_time = min(sleep_time * 2, max_sleep_time)
+                logger.debug("Resetting failure count to '{}'".format(num_fails))
             
-            logger.debug("Failed to find new content '{}' times in a row, sleeping for '{}' seconds".format(num_fails, sleep_time))
+            logger.debug("Sleeping for '{}' seconds".format(sleep_time))
             time.sleep(sleep_time)
 
     # One final check to see if there's anything in the buffer to flush

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -85,6 +85,10 @@ def _stream_logs(byte_size,
     end = byte_size - 1
     available = 0
     last_modified = None
+    sleepTime = 1
+    maxSleepTime = 15
+    numFails = 0
+    numFailsForBackoff = 3
 
     # Try to get the initial properties so there's no waiting.
     # If the storage call fails, we'll just sleep and try again after.
@@ -100,6 +104,10 @@ def _stream_logs(byte_size,
     while (_blob_is_not_complete(metadata) or start < available):
 
         while start < available:
+            # Success! Reset our polling backoff.
+            sleepTime = 1
+            numFails = 0
+
             try:
                 old_byte_size = len(stream.getvalue())
                 blob_service.get_blob_to_stream(
@@ -173,7 +181,14 @@ def _stream_logs(byte_size,
         # If no new data available but not complete, sleep before trying
         # to process additional data.
         if (_blob_is_not_complete(metadata) and start >= available):
-            time.sleep(1)
+            numFails += 1
+            
+            if numFails >= numFailsForBackoff:
+                numFails = 0
+                sleepTime = min(sleepTime * 2, maxSleepTime)
+            
+            logger.debug("Failed to find new content '{}' times in a row, sleeping for '{}' seconds".format(numFails, sleepTime))
+            time.sleep(sleepTime)
 
     # One final check to see if there's anything in the buffer to flush
     # E.g., metadata has been set and start == available, but the log file

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -85,10 +85,10 @@ def _stream_logs(byte_size,
     end = byte_size - 1
     available = 0
     last_modified = None
-    sleepTime = 1
-    maxSleepTime = 15
-    numFails = 0
-    numFailsForBackoff = 3
+    sleep_time = 1
+    max_sleep_time = 15
+    num_fails = 0
+    num_fails_for_backoff = 3
 
     # Try to get the initial properties so there's no waiting.
     # If the storage call fails, we'll just sleep and try again after.
@@ -105,8 +105,8 @@ def _stream_logs(byte_size,
 
         while start < available:
             # Success! Reset our polling backoff.
-            sleepTime = 1
-            numFails = 0
+            sleep_time = 1
+            num_fails = 0
 
             try:
                 old_byte_size = len(stream.getvalue())
@@ -181,14 +181,14 @@ def _stream_logs(byte_size,
         # If no new data available but not complete, sleep before trying
         # to process additional data.
         if (_blob_is_not_complete(metadata) and start >= available):
-            numFails += 1
+            num_fails += 1
             
-            if numFails >= numFailsForBackoff:
-                numFails = 0
-                sleepTime = min(sleepTime * 2, maxSleepTime)
+            if num_fails >= num_fails_for_backoff:
+                num_fails = 0
+                sleep_time = min(sleep_time * 2, max_sleep_time)
             
-            logger.debug("Failed to find new content '{}' times in a row, sleeping for '{}' seconds".format(numFails, sleepTime))
-            time.sleep(sleepTime)
+            logger.debug("Failed to find new content '{}' times in a row, sleeping for '{}' seconds".format(num_fails, sleep_time))
+            time.sleep(sleep_time)
 
     # One final check to see if there's anything in the buffer to flush
     # E.g., metadata has been set and start == available, but the log file

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -173,7 +173,7 @@ def _stream_logs(byte_size,
         # If no new data available but not complete, sleep before trying
         # to process additional data.
         if (_blob_is_not_complete(metadata) and start >= available):
-            time.sleep(5)
+            time.sleep(1)
 
     # One final check to see if there's anything in the buffer to flush
     # E.g., metadata has been set and start == available, but the log file


### PR DESCRIPTION
Tried to DOS one of our Azure Storage accounts, couldn't make it happen with multiple clients on a 0 second delay. This reduces the time before we query for logs again to 1 second, which will be a partial improvement to perceived latency. I don't see any reason to introduce more complex transient fault handling for now - AZ Storage handles it pretty seamlessly as far as I can tell.

Fixes #97 
