### PR TITLE
Log streaming UX

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -197,7 +197,7 @@ def _stream_logs(byte_size,
             total_sleep_time = sleep_time + rnd
             logger.debug("Base sleep time: '{}' random delay: '{}' total: '{}' seconds".format(
                 sleep_time, rnd, total_sleep_time))
-            time.sleep(sleep_time)
+            time.sleep(total_sleep_time)
 
     # One final check to see if there's anything in the buffer to flush
     # E.g., metadata has been set and start == available, but the log file

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -9,6 +9,7 @@ import sys
 import os
 import tarfile
 import requests
+from random import uniform
 from datetime import datetime, timedelta
 from io import BytesIO
 import time
@@ -58,7 +59,7 @@ def acr_build_show_logs(cmd,
     account_name, endpoint_suffix, container_name, blob_name, sas_token = _get_blob_info(
         log_file_sas)
 
-    byte_size = 1024*4
+    byte_size = 1024*1
     timeout_in_minutes = 30
     timeout_in_seconds = timeout_in_minutes * 60
 
@@ -182,14 +183,20 @@ def _stream_logs(byte_size,
         # to process additional data.
         if (_blob_is_not_complete(metadata) and start >= available):
             num_fails += 1
-            
-            logger.debug("Failed to find new content '{}' times in a row".format(num_fails))
+
+            logger.debug(
+                "Failed to find new content '{}' times in a row".format(num_fails))
             if num_fails >= num_fails_for_backoff:
                 num_fails = 0
                 sleep_time = min(sleep_time * 2, max_sleep_time)
-                logger.debug("Resetting failure count to '{}'".format(num_fails))
-            
-            logger.debug("Sleeping for '{}' seconds".format(sleep_time))
+                logger.debug(
+                    "Resetting failure count to '{}'".format(num_fails))
+
+            # 1.0 <= x < 2.0
+            rnd = uniform(1, 2)
+            total_sleep_time = sleep_time + rnd
+            logger.debug("Base sleep time: '{}' random delay: '{}' total: '{}' seconds".format(
+                sleep_time, rnd, total_sleep_time))
             time.sleep(sleep_time)
 
     # One final check to see if there's anything in the buffer to flush


### PR DESCRIPTION
- Adds a random delay between 1 and 2 seconds when the client sleeps for log streaming on top of the linear backoff.
- Reduces the buffer size to 1KB (down from 4) to give the illusion of "faster" log streaming. Basically you'll see more prints which cause the terminal to move up at a jittery pace rather than just barfing one big 4K chunk all at once. So it feels like you make more progress even though in reality you've made the same. This could be reduced even more but it results in more RPS to storage which I think we should avoid.