### PR TITLE
Deprecate build-task and redirect to acr task instead.

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/commands.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/commands.py
@@ -155,7 +155,8 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.command('build', 'acr_build')
 
     # Deprecated (for backward compatibility).
-    with self.command_group('acr build-task', acr_build_task_util) as g:
+    with self.command_group('acr build-task', acr_build_task_util, 
+                            deprecate_info=self.deprecate(redirect='acr task', hide=True)) as g: # This command group is deprecated and will be hidden immediately.
         g.command('create', 'acr_build_task_create')
         g.show_command('show', 'acr_build_task_show')
         g.command('list', 'acr_build_task_list', table_transformer=task_output_format)


### PR DESCRIPTION
Fixes #181 