### PR TITLE
Filename fix in acr run example

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
@@ -61,7 +61,7 @@ helps['acr run'] = """
             az acr run -r myregistry -f bash-echo.yaml .
         - name: Queue a remote git context with streaming logs.
           text: >
-            az acr run -r myregistry https://github.com/Azure-Samples/acr-build-helloworld-node.git -f abc.yaml
+            az acr run -r myregistry https://github.com/Azure-Samples/acr-build-helloworld-node.git -f acb.yaml
     """
 
 helps['acr check-name'] = """


### PR DESCRIPTION
Change filename for acr run help example from abc.yaml to acb.yaml.