### PR TITLE
allow dockerfile outside of source_location folder

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -40,7 +40,7 @@ def acr_build(cmd,
               timeout=None,
               arg=None,
               secret_arg=None,
-              docker_file_path='Dockerfile',
+              docker_file_path='',
               no_format=False,
               no_push=False,
               no_logs=False,
@@ -57,7 +57,12 @@ def acr_build(cmd,
             raise CLIError(
                 "Source location should be a local directory path or remote URL.")
 
-        _check_local_docker_file(source_location, docker_file_path)
+        # NOTE: If docker_file_path is not specified, the default is Dockerfile in source_location.
+        # Otherwise, it's based on current working directory.
+        if not docker_file_path:
+            docker_file_path = os.path.join(source_location, "Dockerfile")
+
+        _check_local_docker_file(docker_file_path)
 
         tar_file_path = os.path.join(tempfile.gettempdir(
         ), 'build_archive_{}.tar.gz'.format(uuid.uuid4().hex))
@@ -124,7 +129,6 @@ def acr_build(cmd,
     return stream_logs(client, run_id, registry_name, resource_group_name, no_format, True)
 
 
-def _check_local_docker_file(source_location, docker_file_path):
-    if not os.path.isfile(os.path.join(source_location, docker_file_path)):
-        raise CLIError("Unable to find '{}' in '{}'.".format(
-            docker_file_path, source_location))
+def _check_local_docker_file(docker_file_path):
+    if not os.path.isfile(docker_file_path):
+        raise CLIError("Unable to find '{}'.".format(docker_file_path))


### PR DESCRIPTION
Previously we always assume Dockerfile is inside context folder. The change allows Dockerfile outside context folder. The behavior is now consistent with docker build. Now you can specify Dockerfile from arbitrary location, eg,

```sh
az acr build -f  ../Dockerfile .
az acr build -f /src/folder1/Dockerfile /src/folder2
```