### PR TITLE
"az acr check-health" human readable helm version and error message

### DIFF
--- a/src/command_modules/azure-cli-acr/HISTORY.rst
+++ b/src/command_modules/azure-cli-acr/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+2.2.10
++++++
+* 'az acr check-health' now displays a human friendly Helm version.
+* 'az acr check-health' raises a warning if an obsolete Helm version is detected.
+
 2.2.9
 +++++
 * Add 'az acr check-health' command.

--- a/src/command_modules/azure-cli-acr/HISTORY.rst
+++ b/src/command_modules/azure-cli-acr/HISTORY.rst
@@ -5,8 +5,7 @@ Release History
 
 2.2.10
 +++++
-* 'az acr check-health' now displays a human friendly Helm version.
-* 'az acr check-health' displays an error message if an obsolete Helm version is detected.
+* Add Helm version validation for 'az acr check-health'
 
 2.2.9
 +++++

--- a/src/command_modules/azure-cli-acr/HISTORY.rst
+++ b/src/command_modules/azure-cli-acr/HISTORY.rst
@@ -6,7 +6,7 @@ Release History
 2.2.10
 +++++
 * 'az acr check-health' now displays a human friendly Helm version.
-* 'az acr check-health' raises a warning if an obsolete Helm version is detected.
+* 'az acr check-health' displays an error message if an obsolete Helm version is detected.
 
 2.2.9
 +++++

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/check_health.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/check_health.py
@@ -163,11 +163,11 @@ def _get_helm_version(ignore_errors):
     if match_obj:
         output = match_obj.group(1)
 
-    print("Helm version:\n{}".format(output))
+    print("Helm version: {}".format(output))
 
-    # Warn the user if current helm version < min required version
+    # Display an error message if the current helm version < min required version
     if match_obj and StrictVersion(output) < StrictVersion(MIN_HELM_VERSION):
-        print_warning("Current Helm version is obsolete. Please upgrade to at least {}".format(MIN_HELM_VERSION))
+        print_error("Current Helm version is obsolete. Please upgrade to at least {}".format(MIN_HELM_VERSION))
 
 
 def _check_health_environment(ignore_errors, yes):

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/check_health.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/check_health.py
@@ -167,7 +167,10 @@ def _get_helm_version(ignore_errors):
 
     # Display an error message if the current helm version < min required version
     if match_obj and StrictVersion(output) < StrictVersion(MIN_HELM_VERSION):
-        print_error("Current Helm version is obsolete. Please upgrade to at least {}".format(MIN_HELM_VERSION))
+        obsolete_ver_error = HELM_VERSION_ERROR.set_error_message(
+            "Current Helm client version is not recommended. Please upgrade your Helm client to at least version {}."
+            .format(MIN_HELM_VERSION))
+        _handle_error(obsolete_ver_error, ignore_errors)
 
 
 def _check_health_environment(ignore_errors, yes):

--- a/src/command_modules/azure-cli-acr/setup.py
+++ b/src/command_modules/azure-cli-acr/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.2.9"
+VERSION = "2.2.10"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Issue: https://github.com/Azure/acr/issues/243

1. Display Helm version on the same line
2. Display human readable Helm version
3. Error message if Helm version < required version

**Default behavior**
![5](https://user-images.githubusercontent.com/20955088/60130096-66875f80-974b-11e9-8d1a-b7562146244d.PNG)

**New changes - Helm v2.14.1**
![1](https://user-images.githubusercontent.com/20955088/60129953-1a3c1f80-974b-11e9-90b3-148065993403.PNG)

**New changes - Helm v2.10.999**
![2](https://user-images.githubusercontent.com/20955088/60129955-1c05e300-974b-11e9-9439-26edf16438b4.PNG)

**New changes - Helm v1.200.400**
![3](https://user-images.githubusercontent.com/20955088/60129957-1dcfa680-974b-11e9-8115-e0d418b3fa4f.PNG)

**New changes - If Helm version regex doesn't match, we display raw output**
![4](https://user-images.githubusercontent.com/20955088/60129962-1f996a00-974b-11e9-91fd-4d1e19127037.PNG)

@ni-reis @sajayantony  
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
