### PR TITLE
[CLI] Add notary version checks to in az acr check-health

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_errors.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_errors.py
@@ -67,6 +67,18 @@ HELM_VERSION_ERROR = ErrorClass(
 )
 
 
+# NOTARY ERRORS
+NOTARY_COMMAND_ERROR = ErrorClass(
+    "NOTARY_COMMAND_ERROR",
+    "Please verify if notary is installed."
+)
+
+NOTARY_VERSION_ERROR = ErrorClass(
+    "NOTARY_VERSION_ERROR",
+    "An error occurred while retrieving notary version. Please make sure that you have the latest Azure CLI version, and that you are using the recommended notary version."
+)
+
+
 # CONNECTIVITY ERRORS
 CONNECTIVITY_DNS_ERROR = ErrorClass(
     "CONNECTIVITY_DNS_ERROR",

--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -25,6 +25,8 @@ ERROR_MSG_DEEP_LINK = "\nPlease refer to https://aka.ms/acr/errors#{} for more i
 MIN_HELM_VERSION = "2.11.0"
 HELM_VERSION_REGEX = re.compile(r'SemVer:"v([.\d]+)"', re.I)
 ACR_CHECK_HEALTH_MSG = "Try running 'az acr check-health -n {} --yes' to diagnose this issue."
+RECOMMENDED_NOTARY_VERSION = "0.6.0"
+NOTARY_VERSION_REGEX = re.compile(r'Version:\s+([.\d]+)', re.I)
 
 
 # Utilities functions
@@ -168,6 +170,46 @@ def _get_helm_version(ignore_errors):
         _handle_error(obsolete_ver_error, ignore_errors)
 
 
+def _get_notary_version(ignore_errors):
+    from ._errors import NOTARY_VERSION_ERROR
+    from .notary import get_notary_command
+    from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+
+    # Notary command check
+    notary_command, error = get_notary_command(is_diagnostics_context=True)
+
+    if error:
+        _handle_error(error, ignore_errors)
+        return
+
+    # Notary version check
+    output, warning, stderr = _subprocess_communicate([notary_command, "version"])
+
+    if stderr:
+        _handle_error(NOTARY_VERSION_ERROR.append_error_message(stderr), ignore_errors)
+        return
+
+    if warning:
+        logger.warning(warning)
+
+    # Retrieve the notary version if regex pattern is found
+    match_obj = NOTARY_VERSION_REGEX.search(output)
+    if match_obj:
+        output = match_obj.group(1)
+
+    print("Notary version: {}".format(output), file=sys.stderr)
+
+    # Display error if the current version does not match the recommended version
+    if match_obj and LooseVersion(output) != LooseVersion(RECOMMENDED_NOTARY_VERSION):
+        version_msg = "upgrade"
+        if LooseVersion(output) > LooseVersion(RECOMMENDED_NOTARY_VERSION):
+            version_msg = "downgrade"
+        obsolete_ver_error = NOTARY_VERSION_ERROR.set_error_message(
+            "Current notary version is not recommended. Please {} your notary client to version {}."
+            .format(version_msg, RECOMMENDED_NOTARY_VERSION))
+        _handle_error(obsolete_ver_error, ignore_errors)
+
+
 def _check_health_environment(ignore_errors, yes):
     from azure.cli.core.util import in_cloud_console
     if in_cloud_console():
@@ -177,6 +219,7 @@ def _check_health_environment(ignore_errors, yes):
     _get_docker_status_and_version(ignore_errors, yes)
     _get_cli_version()
     _get_helm_version(ignore_errors)
+    _get_notary_version(ignore_errors)
 
 
 # Checks for the connectivity

--- a/src/azure-cli/azure/cli/command_modules/acr/notary.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/notary.py
@@ -1,0 +1,38 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from knack.util import CLIError
+from knack.log import get_logger
+
+logger = get_logger(__name__)
+
+
+def get_notary_command(is_diagnostics_context=False):
+    from ._errors import NOTARY_COMMAND_ERROR
+    notary_command = "notary"
+
+    from subprocess import PIPE, Popen
+    try:
+        p = Popen([notary_command, "--help"], stdout=PIPE, stderr=PIPE)
+        _, stderr = p.communicate()
+    except OSError as e:
+        logger.debug("Could not run '%s' command. Exception: %s", notary_command, str(e))
+        # The executable may not be discoverable in WSL so retry *.exe once
+        try:
+            notary_command = 'notary.exe'
+            p = Popen([notary_command, "--help"], stdout=PIPE, stderr=PIPE)
+            _, stderr = p.communicate()
+        except OSError as inner:
+            logger.debug("Could not run '%s' command. Exception: %s", notary_command, str(inner))
+            if is_diagnostics_context:
+                return None, NOTARY_COMMAND_ERROR
+            raise CLIError(NOTARY_COMMAND_ERROR.get_error_message())
+
+    if stderr:
+        if is_diagnostics_context:
+            return None, NOTARY_COMMAND_ERROR.append_error_message(stderr.decode())
+        raise CLIError(NOTARY_COMMAND_ERROR.append_error_message(stderr.decode()).get_error_message())
+
+    return notary_command, None


### PR DESCRIPTION
This adds a docker notary version compatibility check to az acr check-health.

Acceptance Criteria:
- Check notary version
- Print the version
- Check if version matches recommended version (0.6.0)
- If version mismatch, output an error

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
