### PR TITLE
[ACR] az acr repository metadata show/update/delete: Add repository metadata API exposure.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -536,7 +536,7 @@ def request_data_from_registry(http_method,
                     json=json_payload,
                     timeout=timeout,
                     verify=(not should_disable_connection_verify()),
-                    stream=get_iter_content,
+                    stream=get_iter_content,  # must enable stream to get content via iter_content
                 )
 
             log_registry_response(response)
@@ -581,8 +581,8 @@ def request_data_from_registry(http_method,
     raise CLIError(errorMessage)
 
 
-def _get_result_from_response(response, result_index, get_raw, chunk_size=128, decode_unicode=False):
-    if get_raw:
+def _get_result_from_response(response, result_index, get_iter_content, chunk_size=128, decode_unicode=False):
+    if get_iter_content:
         return response.iter_content(chunk_size=chunk_size, decode_unicode=decode_unicode)
     if result_index is not None:  # 0 is an acceptable result_index
         return response.json()[result_index]

--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -586,8 +586,7 @@ def _get_result_from_response(response, result_index, get_iter_content, chunk_si
         return response.iter_content(chunk_size=chunk_size, decode_unicode=decode_unicode)
     if result_index is not None:  # 0 is an acceptable result_index
         return response.json()[result_index]
-    else:
-        return response.json()
+    return response.json()
 
 
 def parse_error_message(error_message, response):

--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -486,6 +486,40 @@ examples:
     text: az acr repository update -n MyRegistry --image hello-world@sha256:abc123 --write-enabled false
 """
 
+helps['acr repository metadata'] = """
+type: group
+short-summary: Manage metadata of repositories (image names) for Azure Container Registries.
+"""
+
+helps['acr repository metadata delete'] = """
+type: command
+short-summary: Delete metadata by key for a repository in an Azure Container Registry.
+long-summary: This command deletes the metadata (if any) specified by a given key for a repository in an Azure Container Registry.
+examples:
+  - name: Delete keyed metadata in a repository from an Azure Container Registry. This deletes metadata under the key 'testKey' in the repository 'hello-world'.
+    text: az acr repository metadata delete -n MyRegistry --repository hello-world --key testKey
+"""
+
+helps['acr repository metadata show'] = """
+type: command
+short-summary: Get the metadata of a repository in an Azure Container Registry.
+long-summary: This command either downloads metadata under a given key in a repository in an Azure Container Registry to a given file, or it shows all available metadata keys.
+examples:
+  - name: Show the available metadata of the repository 'hello-world'.
+    text: az acr repository metadata show -n MyRegistry --repository hello-world
+  - name: Download the metadata under key 'testKey' in repository 'hello-world' to the file 'testFile.out' in the current directory.
+    text: az acr repository metadata show -n MyRegistry --repository hello-world --key testKey --file testFile.out
+"""
+
+helps['acr repository metadata update'] = """
+type: command
+short-summary: Update metadata by key of a repository in an Azure Container Registry by uploading local file.
+long-summary: This command sets the metadata under a given key of a repository in an Azure Container Registry to the contents of a specified local file.
+examples:
+  - name: Update the metadata under key 'testKey' in repository 'hello-world' with contents of the file 'testFile.in' in the current directory.
+    text: az acr repository metadata update -n MyRegistry --repository hello-world --key testKey --file testFile.in
+"""
+
 helps['acr run'] = """
 type: command
 short-summary: Queues a quick run providing streamed logs for an Azure Container Registry.

--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -488,36 +488,52 @@ examples:
 
 helps['acr repository metadata'] = """
 type: group
-short-summary: Manage metadata of repositories (image names) for Azure Container Registries.
+short-summary: Manage metadata of repositories (image names), manifests, or tags for Azure Container Registries.
 """
 
 helps['acr repository metadata delete'] = """
 type: command
-short-summary: Delete metadata by key for a repository in an Azure Container Registry.
-long-summary: This command deletes the metadata (if any) specified by a given key for a repository in an Azure Container Registry.
+short-summary: Delete metadata by key for a repository, tag, or manifest in an Azure Container Registry.
+long-summary: This command deletes the metadata (if any) specified by a given key for a repository, a repository's tag, or a repository's manifest in an Azure Container Registry.
 examples:
-  - name: Delete keyed metadata in a repository from an Azure Container Registry. This deletes metadata under the key 'testKey' in the repository 'hello-world'.
+  - name: Delete metadata under the key 'testKey' for the repository 'hello-world'.
     text: az acr repository metadata delete -n MyRegistry --repository hello-world --key testKey
+  - name: Delete metadata under the key 'testKey' for the tag 'latest' in the repository 'hello-world'.
+    text: az acr repository metadata delete -n MyRegistry --image hello-world:latest --key testKey
+  - name: Delete metadata under the key 'testKey' for the manifest with digest 'sha256:abc123' in the repository 'hello-world'.
+    text: az acr repository metadata delete -n MyRegistry --image hello-world@sha256:abc123 --key testKey
 """
 
 helps['acr repository metadata show'] = """
 type: command
-short-summary: Get the metadata of a repository in an Azure Container Registry.
-long-summary: This command either downloads metadata under a given key in a repository in an Azure Container Registry to a given file, or it shows all available metadata keys.
+short-summary: Get the metadata of a repository, tag, or manifest in an Azure Container Registry.
+long-summary: This command either downloads metadata under a given key in a repository, a repository's tag, or a repository's manifest in an Azure Container Registry to a given file, or it shows all available metadata keys.
 examples:
   - name: Show the available metadata of the repository 'hello-world'.
     text: az acr repository metadata show -n MyRegistry --repository hello-world
-  - name: Download the metadata under key 'testKey' in repository 'hello-world' to the file 'testFile.out' in the current directory.
+  - name: Show the available metadata of the tag 'latest' in the repository 'hello-world'.
+    text: az acr repository metadata show -n MyRegistry --image hello-world:latest
+  - name: Show the available metadata of the manifest with digest 'sha256:abc123' in the repository 'hello-world'.
+    text: az acr repository metadata show -n MyRegistry --image hello-world@sha256:abc123
+  - name: Download the metadata under key 'testKey' for the repository 'hello-world' to the file 'testFile.out' in the current directory.
     text: az acr repository metadata show -n MyRegistry --repository hello-world --key testKey --file testFile.out
+  - name: Download the metadata under key 'testKey' for the tag 'latest' in the repository 'hello-world' to the file 'testFile.out' in the current directory.
+    text: az acr repository metadata show -n MyRegistry --image hello-world:latest --key testKey --file testFile.out
+  - name: Download the metadata under key 'testKey' for the manifest with digest 'sha256:abc123' in the repository 'hello-world' to the file 'testFile.out' in the current directory.
+    text: az acr repository metadata show -n MyRegistry --image hello-world@sha256:abc123 --key testKey --file testFile.out
 """
 
 helps['acr repository metadata update'] = """
 type: command
-short-summary: Update metadata by key of a repository in an Azure Container Registry by uploading local file.
-long-summary: This command sets the metadata under a given key of a repository in an Azure Container Registry to the contents of a specified local file.
+short-summary: Update metadata by key of a repository tag, or manifest in an Azure Container Registry by uploading local file.
+long-summary: This command sets the metadata under a given key of a repository, a repository's tag, or a repository's manifest in an Azure Container Registry to the contents of a specified local file.
 examples:
-  - name: Update the metadata under key 'testKey' in repository 'hello-world' with contents of the file 'testFile.in' in the current directory.
+  - name: Update the metadata under key 'testKey' for the repository 'hello-world' with contents of the file 'testFile.in' in the current directory.
     text: az acr repository metadata update -n MyRegistry --repository hello-world --key testKey --file testFile.in
+  - name: Update the metadata under key 'testKey' for the tag 'latest' in the repository 'hello-world' with contents of the file 'testFile.in' in the current directory.
+    text: az acr repository metadata update -n MyRegistry --image hello-world:latest --key testKey --file testFile.in
+  - name: Update the metadata under key 'testKey' for the manifest with digest 'sha256:abc123' in the repository 'hello-world' with contents of the file 'testFile.in' in the current directory.
+    text: az acr repository metadata update -n MyRegistry --image hello-world@abc123 --key testKey --file testFile.in
 """
 
 helps['acr run'] = """

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -129,7 +129,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
 
     with self.argument_context('acr repository metadata') as c:
         c.argument('key', help="The name of the key used to access specific metadata.")
-        c.argument('file', help="Path to file for upload/download of metadata.")
+        c.argument('file', help="The path to a file for upload/download of metadata.")
 
     with self.argument_context('acr create') as c:
         c.argument('registry_name', completer=None, validator=None)

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -127,6 +127,10 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
     with self.argument_context('acr repository untag') as c:
         c.argument('image', options_list=['--image', '-t'], help="The name of the image. May include a tag in the format 'name:tag'.")
 
+    with self.argument_context('acr repository metadata') as c:
+        c.argument('key', help="The name of the key used to access specific metadata.")
+        c.argument('file', help="Path to file for upload/download of metadata.")
+
     with self.argument_context('acr create') as c:
         c.argument('registry_name', completer=None, validator=None)
         c.argument('deployment_name', validator=None)

--- a/src/azure-cli/azure/cli/command_modules/acr/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/commands.py
@@ -193,7 +193,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.command('update', 'acr_repository_update')
         g.command('delete', 'acr_repository_delete')
         g.command('untag', 'acr_repository_untag')
-        g.command('metadata show', 'acr_repository_metadata_show')
+        g.show_command('metadata show', 'acr_repository_metadata_show')
         g.command('metadata update', 'acr_repository_metadata_update')
         g.command('metadata delete', 'acr_repository_metadata_delete')
 

--- a/src/azure-cli/azure/cli/command_modules/acr/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/commands.py
@@ -193,6 +193,9 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.command('update', 'acr_repository_update')
         g.command('delete', 'acr_repository_delete')
         g.command('untag', 'acr_repository_untag')
+        g.command('metadata show', 'acr_repository_metadata_show')
+        g.command('metadata update', 'acr_repository_metadata_update')
+        g.command('metadata delete', 'acr_repository_metadata_delete')
 
     with self.command_group('acr webhook', acr_webhook_util) as g:
         g.command('list', 'acr_webhook_list')

--- a/src/azure-cli/azure/cli/command_modules/acr/repository.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/repository.py
@@ -436,12 +436,12 @@ def acr_repository_metadata_show(cmd,
                                  registry_name,
                                  repository,
                                  key=None,
-                                 file_out=None,
+                                 file=None,
                                  resource_group_name=None,  # pylint: disable=unused-argument
                                  tenant_suffix=None,
                                  username=None,
                                  password=None):
-    _validate_parameters_out(key, file_out)
+    _validate_parameters_out(key, file)
 
     # To get value of keyed metadata, get content as iter_content and write to file.
     get_iter_content = key is not None
@@ -459,10 +459,10 @@ def acr_repository_metadata_show(cmd,
         get_iter_content=get_iter_content)
 
     if get_iter_content:
-        with open(file_out, 'wb') as f:
+        with open(file, 'wb') as f:
             for chunk in result:
                 f.write(chunk)
-        return "Wrote metadata for key '{}' to file {}".format(key, file_out)
+        return "Wrote metadata for key '{}' to file {}".format(key, file)
     else:
         return result
 
@@ -557,9 +557,9 @@ def _validate_parameters(repository, image):
         raise CLIError('Usage error: --image IMAGE | --repository REPOSITORY')
 
 
-def _validate_parameters_out(key, file_out):
-    if bool(key) != bool(file_out):
-        raise CLIError('Usage error: --key KEY --file-out FILE_OUT')
+def _validate_parameters_out(key, file):
+    if bool(key) != bool(file):
+        raise CLIError('Usage error: --key KEY --file FILE')
 
 
 def _parse_image_name(image, allow_digest=False):

--- a/src/azure-cli/azure/cli/command_modules/acr/repository.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/repository.py
@@ -462,7 +462,8 @@ def acr_repository_metadata_show(cmd,
         with open(file, 'wb') as f:
             for chunk in result:
                 f.write(chunk)
-        return "Wrote metadata for key '{}' to file {}".format(key, file)
+        print("Wrote downloaded metadata for key '{}' to file {}".format(key, file))
+        return None
     else:
         return result
 

--- a/src/azure-cli/azure/cli/command_modules/acr/repository.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/repository.py
@@ -443,6 +443,7 @@ def acr_repository_metadata_show(cmd,
                                  password=None):
     _validate_parameters_out(key, file_out)
 
+    # To get value of keyed metadata, get content as iter_content and write to file.
     get_iter_content = key is not None
 
     result = _acr_repository_metadata_helper(
@@ -540,7 +541,7 @@ def acr_repository_metadata_delete(cmd,
         permission=RepoAccessTokenPermission.DELETE_META_READ.value)
 
     user_confirmation("Are you sure you want to delete metadata in the key '{}'"
-                        " of the repository '{}'?".format(key, repository), yes)
+                      " of the repository '{}'?".format(key, repository), yes)
     path = _get_repository_metadata_path(repository, key)
 
     return request_data_from_registry(

--- a/src/azure-cli/azure/cli/command_modules/acr/repository.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/repository.py
@@ -464,8 +464,7 @@ def acr_repository_metadata_show(cmd,
                 f.write(chunk)
         print("Wrote downloaded metadata for key '{}' to file {}".format(key, file))
         return None
-    else:
-        return result
+    return result
 
 
 def acr_repository_metadata_update(cmd,

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
@@ -409,7 +409,7 @@ class AcrMockCommandsTests(unittest.TestCase):
             timeout=300,
             verify=mock.ANY,
             stream=False)
-    
+
     @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
     @mock.patch('requests.request', autospec=True)
     def test_repository_metadata_show(self, mock_requests_metadata_get, mock_get_access_credentials):

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
@@ -461,7 +461,7 @@ class AcrMockCommandsTests(unittest.TestCase):
                                          registry_name='testregistry',
                                          repository='testrepository',
                                          key='testkey',
-                                         file_out='testfileout')
+                                         file='testfileout')
             mock_requests_metadata_get.assert_called_with(
                 method='get',
                 url='https://testregistry.azurecr.io/acr/v1/testrepository/_metadata/testkey',

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
@@ -21,7 +21,10 @@ from azure.cli.command_modules.acr.repository import (
     acr_repository_show,
     acr_repository_update,
     acr_repository_delete,
-    acr_repository_untag
+    acr_repository_untag,
+    acr_repository_metadata_show,
+    acr_repository_metadata_update,
+    acr_repository_metadata_delete,
 )
 from azure.cli.command_modules.acr.helm import (
     acr_helm_list,
@@ -75,7 +78,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             },
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
         # List repositories using Bearer auth
         mock_get_access_credentials.return_value = 'testregistry.azurecr.io', EMPTY_GUID, 'password'
@@ -90,7 +94,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             },
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
     @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
     @mock.patch('requests.request', autospec=True)
@@ -128,7 +133,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             },
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
         # Show tags using Bearer auth
         mock_get_access_credentials.return_value = 'testregistry.azurecr.io', EMPTY_GUID, 'password'
@@ -146,7 +152,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             },
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
     @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
     @mock.patch('requests.request', autospec=True)
@@ -181,7 +188,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             },
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
         # Show manifests using Bearer auth with detail
         mock_get_access_credentials.return_value = 'testregistry.azurecr.io', EMPTY_GUID, 'password'
@@ -197,7 +205,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             },
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
     @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
     @mock.patch('requests.request', autospec=True)
@@ -226,7 +235,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
         # Show attributes for an image by tag
         acr_repository_show(cmd,
@@ -239,7 +249,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
         # Show attributes for an image by manifest digest
         acr_repository_show(cmd,
@@ -252,11 +263,12 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
     @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
     @mock.patch('requests.request', autospec=True)
-    def test_repository_show(self, mock_requests_get, mock_get_access_credentials):
+    def test_repository_update(self, mock_requests_update, mock_get_access_credentials):
         cmd = self._setup_cmd()
 
         response = mock.MagicMock()
@@ -266,7 +278,7 @@ class AcrMockCommandsTests(unittest.TestCase):
             'registry': 'testregistry.azurecr.io',
             'imageName': 'testrepository'
         }).encode()
-        mock_requests_get.return_value = response
+        mock_requests_update.return_value = response
 
         mock_get_access_credentials.return_value = 'testregistry.azurecr.io', 'username', 'password'
 
@@ -275,7 +287,7 @@ class AcrMockCommandsTests(unittest.TestCase):
                               registry_name='testregistry',
                               repository='testrepository',
                               write_enabled='false')
-        mock_requests_get.assert_called_with(
+        mock_requests_update.assert_called_with(
             method='patch',
             url='https://testregistry.azurecr.io/acr/v1/testrepository',
             headers=get_authorization_header('username', 'password'),
@@ -284,14 +296,15 @@ class AcrMockCommandsTests(unittest.TestCase):
                 'writeEnabled': 'false'
             },
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
         # Update attributes for an image by tag
         acr_repository_update(cmd,
                               registry_name='testregistry',
                               image='testrepository:testtag',
                               write_enabled='false')
-        mock_requests_get.assert_called_with(
+        mock_requests_update.assert_called_with(
             method='patch',
             url='https://testregistry.azurecr.io/acr/v1/testrepository/_tags/testtag',
             headers=get_authorization_header('username', 'password'),
@@ -300,14 +313,15 @@ class AcrMockCommandsTests(unittest.TestCase):
                 'writeEnabled': 'false'
             },
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
         # Update attributes for an image by manifest digest
         acr_repository_update(cmd,
                               registry_name='testregistry',
                               image='testrepository@sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7',
                               write_enabled='false')
-        mock_requests_get.assert_called_with(
+        mock_requests_update.assert_called_with(
             method='patch',
             url='https://testregistry.azurecr.io/acr/v1/testrepository/_manifests/sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7',
             headers=get_authorization_header('username', 'password'),
@@ -316,7 +330,8 @@ class AcrMockCommandsTests(unittest.TestCase):
                 'writeEnabled': 'false'
             },
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
     @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
     @mock.patch('azure.cli.command_modules.acr.repository._get_manifest_digest', autospec=True)
@@ -344,7 +359,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
         # Delete image by tag
         acr_repository_delete(cmd,
@@ -358,7 +374,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
         # Delete image by manifest digest
         acr_repository_delete(cmd,
@@ -372,7 +389,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
         # Untag image
         acr_repository_untag(cmd,
@@ -385,7 +403,139 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
+    
+    @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
+    @mock.patch('requests.request', autospec=True)
+    def test_repository_metadata_show(self, mock_requests_metadata_get, mock_get_access_credentials):
+        cmd = self._setup_cmd()
+
+        response = mock.MagicMock()
+        response.headers = {}
+        response.status_code = 200
+        response.content = json.dumps({
+            'registry': 'testregistry.azurecr.io',
+            'imageName': 'testrepository',
+            'metadata': [
+                'testkey1',
+                'testkey2',
+            ],
+        }).encode()
+
+        mock_iter_content = mock.MagicMock()
+        testfilecontents = ['0' * 128, 'testfilecontents']
+        mock_iter_content.return_value = iter(testfilecontents)
+        response.iter_content = mock_iter_content
+
+        mock_requests_metadata_get.return_value = response
+
+        mock_get_access_credentials.return_value = 'testregistry.azurecr.io', 'username', 'password'
+
+        # Show metadata for a repository
+        acr_repository_metadata_show(cmd,
+                                     registry_name='testregistry',
+                                     repository='testrepository')
+        mock_requests_metadata_get.assert_called_with(
+            method='get',
+            url='https://testregistry.azurecr.io/acr/v1/testrepository/_metadata',
+            headers=get_authorization_header('username', 'password'),
+            params=None,
+            json=None,
+            timeout=300,
+            verify=mock.ANY,
+            stream=False)
+
+        builtins_open = '__builtin__.open' if sys.version_info[0] < 3 else 'builtins.open'
+
+        # Show metadata for a repository by key
+        with mock.patch(builtins_open) as mock_open:
+            mock_open.return_value = mock.MagicMock()
+            acr_repository_metadata_show(cmd,
+                                         registry_name='testregistry',
+                                         repository='testrepository',
+                                         key='testkey',
+                                         file_out='testfileout')
+            mock_open.assert_called_with('testfileout', 'wb')
+            mock_iter_content.assert_called_with(chunk_size=128, decode_unicode=False)
+            mock_requests_metadata_get.assert_called_with(
+                method='get',
+                url='https://testregistry.azurecr.io/acr/v1/testrepository/_metadata/testkey',
+                headers=get_authorization_header('username', 'password'),
+                params=None,
+                json=None,
+                timeout=300,
+                verify=mock.ANY,
+                stream=True)
+            for call, teststring in zip(mock_open.return_value.__enter__.return_value.write.mock_calls, testfilecontents):
+                call.assert_called_with(teststring.encode())
+
+    @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
+    @mock.patch('requests.request', autospec=True)
+    def test_repository_metadata_update(self, mock_requests_metadata_update, mock_get_access_credentials):
+        cmd = self._setup_cmd()
+
+        response = mock.MagicMock()
+        response.headers = {}
+        response.status_code = 200
+        response.content = json.dumps({
+            'registry': 'testregistry.azurecr.io',
+            'imageName': 'testrepository'
+        }).encode()
+        mock_requests_metadata_update.return_value = response
+
+        mock_get_access_credentials.return_value = 'testregistry.azurecr.io', 'username', 'password'
+        
+        builtins_open = '__builtin__.open' if sys.version_info[0] < 3 else 'builtins.open'
+
+        # Update metadata for a repository by key with data from file
+        with mock.patch(builtins_open) as mock_open:
+            mock_open.return_value = mock.MagicMock()
+            acr_repository_metadata_update(cmd,
+                                           registry_name='testregistry',
+                                           repository='testrepository',
+                                           key='testkey',
+                                           file='testfile')
+            mock_open.assert_called_with('testfile', 'rb')
+            mock_requests_metadata_update.assert_called_with(
+                method='put',
+                url='https://testregistry.azurecr.io/acr/v1/testrepository/_metadata/testkey',
+                headers=get_authorization_header('username', 'password'),
+                params=None,
+                data=mock_open.return_value.__enter__.return_value,
+                timeout=300,
+                verify=mock.ANY,
+                stream=False)
+
+    @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
+    @mock.patch('azure.cli.command_modules.acr.repository._get_manifest_digest', autospec=True)
+    @mock.patch('requests.request', autospec=True)
+    def test_repository_metadata_delete(self, mock_requests_metadata_delete, mock_get_manifest_digest, mock_get_access_credentials):
+        cmd = self._setup_cmd()
+
+        delete_response = mock.MagicMock()
+        delete_response.headers = {}
+        delete_response.status_code = 200
+        mock_requests_metadata_delete.return_value = delete_response
+
+        mock_get_access_credentials.return_value = 'testregistry.azurecr.io', 'username', 'password'
+        mock_get_manifest_digest.return_value = 'sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7'
+
+        # Delete metadata for a repository by key
+        acr_repository_metadata_delete(cmd,
+                                       registry_name='testregistry',
+                                       repository='testrepository',
+                                       key='testkey',
+                                       yes=True)
+        mock_requests_metadata_delete.assert_called_with(
+            method='delete',
+            url='https://testregistry.azurecr.io/acr/v1/testrepository/_metadata/testkey',
+            headers=get_authorization_header('username', 'password'),
+            params=None,
+            json=None,
+            timeout=300,
+            verify=mock.ANY,
+            stream=False)
 
     @mock.patch('azure.cli.core._profile.Profile.get_subscription_id', autospec=True)
     @mock.patch('azure.cli.command_modules.acr._docker_utils.get_registry_by_name', autospec=True)
@@ -549,7 +699,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
     @mock.patch('azure.cli.command_modules.acr.helm.get_access_credentials', autospec=True)
     @mock.patch('requests.request', autospec=True)
@@ -583,7 +734,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
         # Show one version of a chart
         acr_helm_show(cmd, 'testregistry', 'mychart1', version='0.2.1', repository='testrepository')
@@ -594,7 +746,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
     @mock.patch('azure.cli.command_modules.acr.helm.get_access_credentials', autospec=True)
     @mock.patch('requests.request', autospec=True)
@@ -617,7 +770,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
         # Delete one version of a chart
         acr_helm_delete(cmd, 'testregistry', 'mychart1', version='0.2.1', repository='testrepository', yes=True)
@@ -628,7 +782,8 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             timeout=300,
-            verify=mock.ANY)
+            verify=mock.ANY,
+            stream=False)
 
     @mock.patch('azure.cli.command_modules.acr.helm.get_access_credentials', autospec=True)
     @mock.patch('requests.request', autospec=True)
@@ -655,7 +810,8 @@ class AcrMockCommandsTests(unittest.TestCase):
                 params=None,
                 data=mock_open.return_value.__enter__.return_value,
                 timeout=300,
-                verify=mock.ANY)
+                verify=mock.ANY,
+                stream=False)
 
         # Push a prov file
         with mock.patch(builtins_open) as mock_open:
@@ -668,7 +824,8 @@ class AcrMockCommandsTests(unittest.TestCase):
                 params=None,
                 data=mock_open.return_value.__enter__.return_value,
                 timeout=300,
-                verify=mock.ANY)
+                verify=mock.ANY,
+                stream=False)
 
         # Force push a chart
         with mock.patch(builtins_open) as mock_open:
@@ -681,7 +838,8 @@ class AcrMockCommandsTests(unittest.TestCase):
                 params=None,
                 data=mock_open.return_value.__enter__.return_value,
                 timeout=300,
-                verify=mock.ANY)
+                verify=mock.ANY,
+                stream=False)
 
     def _setup_cmd(self):
         cmd = mock.MagicMock()


### PR DESCRIPTION
**Description**  
Enables listing of metadata keys, downloading metadata by key to file, updating metadata by key from file, and deleting metadata by key. Metadata is associated with a repository, manifest, or tag.

In alignment with the backend design, metadata can currently be arbitrary binary, hence the use of files (though we discard filenames). It should be easy to update `repository.py` and `_docker_utils.py` to restrict the accepted and returned content types to, say, JSON strings, instead of reading to or writing from files.

Furthermore, no keys are currently reserved for system use. For system-reserved metadata, it may (?) be useful to look at so-called "attributes" revealed via commands like `az acr repository show` (i.e., the commands here but without the term `metadata`). Alternatively, it should be easy to update `repository.py` to restrict the read/write capabilities for certain keys, e.g. those beginning with `__`.

Due to lack of backend support, there is currently no indexing or journaling/history.

**Testing Guide**  
Assuming your ACR registry is named `registryName` and it contains a repository named `repositoryName`:
1. List current metadata:
```
az acr repository metadata show --name registryName --repository repositoryName
```
2. Create a text file `testFile.in` in the current directory with some content. Upload it as metadata under the key `testKey`:
```
echo "test file contents" > testFile.in
az acr repository metadata update --name registryName --repository repositoryName --key testKey --file testFile.in
```
3. See that the repository now has metadata with key `testKey`:
```
az acr repository metadata show --name registryName --repository repositoryName
```
4. Download the metadata under key `testKey` to file `testFile.out` in the current directory; it should have the same content as `testFile.in`:
```
az acr repository metadata show --name registryName --repository repositoryName --key testKey --file testFile.out
cat testFile.out
```
5. Delete metadata under key `testKey`:
```
az acr repository metadata delete --name registryName --repository repositoryName --key testKey
```
6. See that the repository no longer has metadata with key `testKey`:
```
az acr repository metadata show --name registryName --repository repositoryName
```
7. The above steps manipulated metadata associated with the entire repository `repositoryName`. To manipulate metadata associated with the `tagName` tag, replace `--repository repositoryName` with `--image repositoryName:tagName`. To manipulate metadata associated with the manifest with digest `sha256:digest`, replace `--repository repositoryName` with `--image repositoryName@sha256:digest` instead.

**History Notes**

[ACR] az acr repository metadata show/update/delete: Add repository metadata API exposure.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
